### PR TITLE
Add IEEE 802.1Q decoder support

### DIFF
--- a/pcap/kraken-pcap/src/main/java/org/krakenapps/pcap/decoder/ethernet/IEEE_802_1Q.java
+++ b/pcap/kraken-pcap/src/main/java/org/krakenapps/pcap/decoder/ethernet/IEEE_802_1Q.java
@@ -1,0 +1,25 @@
+package org.krakenapps.pcap.decoder.ethernet;
+
+public class IEEE_802_1Q {
+    private int pcp;
+    private int dei;
+    private int vid;
+
+    public IEEE_802_1Q(int pcp, int dei, int vid) {
+	this.pcp = pcp;
+	this.dei = dei;
+	this.vid = vid;
+    }
+
+    public int getPriorityCodePoint() {
+	return pcp;
+    }
+
+    public int getDropEligibleIndicator() {
+	return dei;
+    }
+
+    public int getvLANIdentifier() {
+	return vid;
+    }
+}


### PR DESCRIPTION
Enhance current EthernetDecoder to support IEEE 802.1Q header.

More information about IEEE 802.1Q, please refer to http://en.wikipedia.org/wiki/IEEE_802.1Q
